### PR TITLE
A few tweaks

### DIFF
--- a/document/core/appendix/index-instructions.rst
+++ b/document/core/appendix/index-instructions.rst
@@ -199,10 +199,10 @@ Instruction                             Binary Opcode     Type                  
 :math:`\I64.\REINTERPRET\K{\_}\F64`     :math:`\hex{BD}`  :math:`[\F64] \to [\I64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
 :math:`\F32.\REINTERPRET\K{\_}\I32`     :math:`\hex{BE}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
 :math:`\F64.\REINTERPRET\K{\_}\I64`     :math:`\hex{BF}`  :math:`[\I64] \to [\F64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
-:math:`\I32.\EXTEND\K{8\_s}`         :math:`\hex{C0}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
-:math:`\I32.\EXTEND\K{16\_s}`        :math:`\hex{C1}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
-:math:`\I64.\EXTEND\K{8\_s}`         :math:`\hex{C2}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
-:math:`\I64.\EXTEND\K{16\_s}`        :math:`\hex{C3}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
-:math:`\I64.\EXTEND\K{32\_s}`        :math:`\hex{C4}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\I32.\EXTEND\K{8\_s}`            :math:`\hex{C0}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\I32.\EXTEND\K{16\_s}`           :math:`\hex{C1}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\I64.\EXTEND\K{8\_s}`            :math:`\hex{C2}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\I64.\EXTEND\K{16\_s}`           :math:`\hex{C3}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\I64.\EXTEND\K{32\_s}`           :math:`\hex{C4}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
 
 ======================================  ================  ==========================================  ========================================  ===============================================================

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -130,7 +130,6 @@ let encode m =
     open Source
     open Ast
     open Values
-    open Memory
 
     let op n = u8 n
     let end_ () = op 0x0b
@@ -260,16 +259,16 @@ let encode m =
       | Unary (I32 I32Op.Clz) -> op 0x67
       | Unary (I32 I32Op.Ctz) -> op 0x68
       | Unary (I32 I32Op.Popcnt) -> op 0x69
-      | Unary (I32 I32Op.Extend8S) -> op 0xc0
-      | Unary (I32 I32Op.Extend16S) -> op 0xc1
-      | Unary (I32 I32Op.Extend32S) -> assert false
+      | Unary (I32 (I32Op.ExtendS Pack8)) -> op 0xc0
+      | Unary (I32 (I32Op.ExtendS Pack16)) -> op 0xc1
+      | Unary (I32 (I32Op.ExtendS Pack32)) -> assert false
 
       | Unary (I64 I64Op.Clz) -> op 0x79
       | Unary (I64 I64Op.Ctz) -> op 0x7a
       | Unary (I64 I64Op.Popcnt) -> op 0x7b
-      | Unary (I64 I64Op.Extend8S) -> op 0xc2
-      | Unary (I64 I64Op.Extend16S) -> op 0xc3
-      | Unary (I64 I64Op.Extend32S) -> op 0xc4
+      | Unary (I64 (I64Op.ExtendS Pack8)) -> op 0xc2
+      | Unary (I64 (I64Op.ExtendS Pack16)) -> op 0xc3
+      | Unary (I64 (I64Op.ExtendS Pack32)) -> op 0xc4
 
       | Unary (F32 F32Op.Abs) -> op 0x8b
       | Unary (F32 F32Op.Neg) -> op 0x8c

--- a/interpreter/exec/eval_numeric.ml
+++ b/interpreter/exec/eval_numeric.ml
@@ -24,9 +24,7 @@ struct
       | Clz -> IXX.clz
       | Ctz -> IXX.ctz
       | Popcnt -> IXX.popcnt
-      | Extend8S -> IXX.extend8_s
-      | Extend16S -> IXX.extend16_s
-      | Extend32S -> IXX.extend32_s
+      | ExtendS sz -> IXX.extend_s (8 * packed_size sz)
     in fun v -> to_value (f (of_value 1 v))
 
   let binop op =

--- a/interpreter/exec/int.ml
+++ b/interpreter/exec/int.ml
@@ -58,9 +58,7 @@ sig
   val clz : t -> t
   val ctz : t -> t
   val popcnt : t -> t
-  val extend8_s : t -> t
-  val extend16_s : t -> t
-  val extend32_s : t -> t
+  val extend_s : int -> t -> t
   val eqz : t -> bool
   val eq : t -> t -> bool
   val ne : t -> t -> bool
@@ -204,13 +202,9 @@ struct
         loop acc' (i - 1) (Rep.shift_right_logical n 1)
     in Rep.of_int (loop 0 Rep.bitwidth x)
 
-  let extendn_s n x =
+  let extend_s n x =
     let shift = Rep.bitwidth - n in
     Rep.shift_right (Rep.shift_left x shift) shift
-
-  let extend8_s x = extendn_s 8 x
-  let extend16_s x = extendn_s 16 x
-  let extend32_s x = extendn_s 32 x
 
   let eqz x = x = Rep.zero
 

--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -7,9 +7,6 @@ type size = int32  (* number of pages *)
 type address = int64
 type offset = int32
 
-type pack_size = Pack8 | Pack16 | Pack32
-type extension = SX | ZX
-
 type memory' = (int, int8_unsigned_elt, c_layout) Array1.t
 type memory = {mutable content : memory'; max : size option}
 type t = memory
@@ -21,11 +18,6 @@ exception SizeLimit
 exception OutOfMemory
 
 let page_size = 0x10000L (* 64 KiB *)
-
-let packed_size = function
-  | Pack8 -> 1
-  | Pack16 -> 2
-  | Pack32 -> 4
 
 let within_limits n = function
   | None -> true

--- a/interpreter/runtime/memory.mli
+++ b/interpreter/runtime/memory.mli
@@ -8,9 +8,6 @@ type size = int32  (* number of pages *)
 type address = int64
 type offset = int32
 
-type pack_size = Pack8 | Pack16 | Pack32
-type extension = SX | ZX
-
 exception Type
 exception Bounds
 exception SizeOverflow
@@ -18,7 +15,6 @@ exception SizeLimit
 exception OutOfMemory
 
 val page_size : int64
-val packed_size : pack_size -> int
 
 val alloc : memory_type -> memory (* raises SizeOverflow, OutOfMemory *)
 val type_of : memory -> memory_type

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -23,7 +23,7 @@ open Types
 
 module IntOp =
 struct
-  type unop = Clz | Ctz | Popcnt | Extend8S | Extend16S | Extend32S
+  type unop = Clz | Ctz | Popcnt | ExtendS of pack_size
   type binop = Add | Sub | Mul | DivS | DivU | RemS | RemU
              | And | Or | Xor | Shl | ShrS | ShrU | Rotl | Rotr
   type testop = Eqz
@@ -57,8 +57,8 @@ type cvtop = (I32Op.cvtop, I64Op.cvtop, F32Op.cvtop, F64Op.cvtop) Values.op
 
 type 'a memop =
   {ty : value_type; align : int; offset : Memory.offset; sz : 'a option}
-type loadop = (Memory.pack_size * Memory.extension) memop
-type storeop = Memory.pack_size memop
+type loadop = (pack_size * extension) memop
+type storeop = pack_size memop
 
 
 (* Expressions *)

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -1,7 +1,6 @@
 open Source
 open Types
 open Values
-open Memory
 open Ast
 
 
@@ -199,11 +198,11 @@ let i64_reinterpret_f64 = Convert (I64 I64Op.ReinterpretFloat)
 let f32_reinterpret_i32 = Convert (F32 F32Op.ReinterpretInt)
 let f64_reinterpret_i64 = Convert (F64 F64Op.ReinterpretInt)
 
-let i32_extend8_s = Unary (I32 I32Op.Extend8S)
-let i32_extend16_s = Unary (I32 I32Op.Extend16S)
-let i64_extend8_s = Unary (I64 I64Op.Extend8S)
-let i64_extend16_s = Unary (I64 I64Op.Extend16S)
-let i64_extend32_s = Unary (I64 I64Op.Extend32S)
+let i32_extend8_s = Unary (I32 (I32Op.ExtendS Pack8))
+let i32_extend16_s = Unary (I32 (I32Op.ExtendS Pack16))
+let i64_extend8_s = Unary (I64 (I64Op.ExtendS Pack8))
+let i64_extend16_s = Unary (I64 (I64Op.ExtendS Pack16))
+let i64_extend32_s = Unary (I64 (I64Op.ExtendS Pack32))
 
 let memory_size = MemorySize
 let memory_grow = MemoryGrow

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -16,12 +16,20 @@ type extern_type =
   | ExternMemoryType of memory_type
   | ExternGlobalType of global_type
 
+type pack_size = Pack8 | Pack16 | Pack32
+type extension = SX | ZX
+
 
 (* Attributes *)
 
 let size = function
   | I32Type | F32Type -> 4
   | I64Type | F64Type -> 8
+
+let packed_size = function
+  | Pack8 -> 1
+  | Pack16 -> 2
+  | Pack32 -> 4
 
 
 (* Subtyping *)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -75,6 +75,15 @@ let global_type = function
   | GlobalType (t, Immutable) -> atom string_of_value_type t
   | GlobalType (t, Mutable) -> Node ("mut", [atom string_of_value_type t])
 
+let pack_size = function
+  | Pack8 -> "8"
+  | Pack16 -> "16"
+  | Pack32 -> "32"
+
+let extension = function
+  | SX -> "_s"
+  | ZX -> "_u"
+
 
 (* Operators *)
 
@@ -101,9 +110,7 @@ struct
     | Clz -> "clz"
     | Ctz -> "ctz"
     | Popcnt -> "popcnt"
-    | Extend8S -> "extend8_s"
-    | Extend16S -> "extend16_s"
-    | Extend32S -> "extend32_s"
+    | ExtendS sz -> "extend" ^ pack_size sz ^ "_s"
 
   let binop xx = function
     | Add -> "add"
@@ -190,15 +197,6 @@ let testop = oper (IntOp.testop, FloatOp.testop)
 let relop = oper (IntOp.relop, FloatOp.relop)
 let cvtop = oper (IntOp.cvtop, FloatOp.cvtop)
 
-let pack_size = function
-  | Memory.Pack8 -> "8"
-  | Memory.Pack16 -> "16"
-  | Memory.Pack32 -> "32"
-
-let extension = function
-  | Memory.SX -> "_s"
-  | Memory.ZX -> "_u"
-
 let memop name {ty; align; offset; _} sz =
   value_type ty ^ "." ^ name ^
   (if offset = 0l then "" else " offset=" ^ nat32 offset) ^
@@ -208,12 +206,12 @@ let loadop op =
   match op.sz with
   | None -> memop "load" op (size op.ty)
   | Some (sz, ext) ->
-    memop ("load" ^ pack_size sz ^ extension ext) op (Memory.packed_size sz)
+    memop ("load" ^ pack_size sz ^ extension ext) op (packed_size sz)
 
 let storeop op =
   match op.sz with
   | None -> memop "store" op (size op.ty)
-  | Some sz -> memop ("store" ^ pack_size sz) op (Memory.packed_size sz)
+  | Some sz -> memop ("store" ^ pack_size sz) op (packed_size sz)
 
 
 (* Expressions *)

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -137,9 +137,13 @@ let type_cvtop at = function
 
 (* Expressions *)
 
+let check_pack sz t at =
+  require (packed_size sz < size t) at "invalid sign extension"
+
 let check_unop unop at =
   match unop with
-  | Values.I32 I32Op.Extend32S -> error at "invalid unary operator"
+  | Values.I32 (IntOp.ExtendS sz) | Values.I64 (IntOp.ExtendS sz) ->
+    check_pack sz (Values.type_of unop) at
   | _ -> ()
 
 let check_memop (c : context) (memop : 'a memop) get_sz at =
@@ -148,9 +152,8 @@ let check_memop (c : context) (memop : 'a memop) get_sz at =
     match get_sz memop.sz with
     | None -> size memop.ty
     | Some sz ->
-      require (memop.ty = I64Type || sz <> Memory.Pack32) at
-        "memory size too big";
-      Memory.packed_size sz
+      check_pack sz memop.ty at;
+      packed_size sz
   in
   require (1 lsl memop.align <= size) at
     "alignment must not be larger than natural"

--- a/test/core/i64.wast
+++ b/test/core/i64.wast
@@ -259,7 +259,7 @@
 (assert_return (invoke "ctz" (i64.const 0x8000000000000000)) (i64.const 63))
 (assert_return (invoke "ctz" (i64.const 0x7fffffffffffffff)) (i64.const 0))
 
-(assert_return (invoke "local.get" (i64.const -1)) (i64.const 64))
+(assert_return (invoke "popcnt" (i64.const -1)) (i64.const 64))
 (assert_return (invoke "popcnt" (i64.const 0)) (i64.const 0))
 (assert_return (invoke "popcnt" (i64.const 0x00008000)) (i64.const 1))
 (assert_return (invoke "popcnt" (i64.const 0x8000800080008000)) (i64.const 4))


### PR DESCRIPTION
Unify handling of pack_size type in interpreter for both load/stores and extend.

Also, fix a couple of merge errors (table layout, spurious test breakage).